### PR TITLE
Small fix in Default DAO on prepopulateAppUser call

### DIFF
--- a/src/groovy/com/the6hours/grails/springsecurity/facebook/DefaultFacebookAuthDao.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/facebook/DefaultFacebookAuthDao.groovy
@@ -83,7 +83,7 @@ class DefaultFacebookAuthDao implements FacebookAuthDao<Object>, InitializingBea
                 }
                 appUser = UserDomainClass.newInstance()
                 if (facebookAuthService && facebookAuthService.respondsTo('prepopulateAppUser', UserDomainClass, FacebookAuthToken)) {
-                    facebookAuthService.prepopulateAppUser(appUser)
+                    facebookAuthService.prepopulateAppUser(appUser, token)
                 } else {
                     appUser[securityConf.userLookup.usernamePropertyName] = "facebook_$token.uid"
                     appUser[securityConf.userLookup.passwordPropertyName] = token.accessToken


### PR DESCRIPTION
The FacebookAuthService method override require a method
prepopulateAppUser accepting 2 parameters (your base spring security
Domain and the Facebook token). The default DAO look for that method
but doesn't call it with the 2 attributes which break at runtime.
