### PR TITLE
update grails.plugins.springsecurity to grails.plugin.springsecurity htt...

### DIFF
--- a/SpringSecurityFacebookGrailsPlugin.groovy
+++ b/SpringSecurityFacebookGrailsPlugin.groovy
@@ -88,7 +88,7 @@ class SpringSecurityFacebookGrailsPlugin {
         if (_facebookDaoName == null) {
             _facebookDaoName = 'facebookAuthDao'
             String _appUserConnectionPropertyName = getConfigValue(conf, 'facebook.domain.appUserConnectionPropertyName', 'facebook.domain.connectionPropertyName')
-            List<String> _roles = getAsStringList(conf.facebook.autoCreate.roles, 'grails.plugins.springsecurity.facebook.autoCreate.roles')
+            List<String> _roles = getAsStringList(conf.facebook.autoCreate.roles, 'grails.plugin.springsecurity.facebook.autoCreate.roles')
             facebookAuthDao(DefaultFacebookAuthDao) {
                 domainClassName = conf.facebook.domain.classname
                 appUserConnectionPropertyName = _appUserConnectionPropertyName
@@ -128,7 +128,7 @@ class SpringSecurityFacebookGrailsPlugin {
         def typesRaw = conf.facebook.filter.types
         List<String> types = null
         if (!typesRaw) {
-            log.warn("Value for 'grails.plugins.springsecurity.facebook.filter.types' is empty")
+            log.warn("Value for 'grails.plugin.springsecurity.facebook.filter.types' is empty")
             typesRaw = conf.facebook.filter.type
         }
 
@@ -150,9 +150,9 @@ class SpringSecurityFacebookGrailsPlugin {
         if (!types || types.empty) {
             log.error("Facebook Authentication filter is not configured. Should be used one of: $validTypes. So '$defaultType' will be used by default.")
             log.error("To configure Facebook Authentication filters you should add to Config.groovy:")
-            log.error("grails.plugins.springsecurity.facebook.filter.types='transparent'")
+            log.error("grails.plugin.springsecurity.facebook.filter.types='transparent'")
             log.error("or")
-            log.error("grails.plugins.springsecurity.facebook.filter.types='redirect,transparent,cookieDirect'")
+            log.error("grails.plugin.springsecurity.facebook.filter.types='redirect,transparent,cookieDirect'")
 
             types = [defaultType]
         }

--- a/scripts/S2InitFacebook.groovy
+++ b/scripts/S2InitFacebook.groovy
@@ -62,7 +62,7 @@ private void fillConfig() {
         configFile.withWriterAppend {
             it.writeLine "\n"
             config.entrySet().each { Map.Entry conf ->
-                it.writeLine "grails.plugins.springsecurity.facebook.$conf.key='$conf.value'"
+                it.writeLine "grails.plugin.springsecurity.facebook.$conf.key='$conf.value'"
             }
         }
     }

--- a/src/docs/guide/2.2 Upgrade Notice.gdoc
+++ b/src/docs/guide/2.2 Upgrade Notice.gdoc
@@ -5,7 +5,7 @@ Client Side authentication (based on Facebook JS SDK) that was default implement
 
 If you want to continue using Client Side authentication, you should add following configuration into @Config.groovy@:
 {code}
-grails.plugins.springsecurity.facebook.filter.type='transparent,cookieDirect'
+grails.plugin.springsecurity.facebook.filter.type='transparent,cookieDirect'
 {code}
 
 See [Filters guide|guide:3.2 Filters] for details.

--- a/src/docs/guide/3.1 Basic Usage.gdoc
+++ b/src/docs/guide/3.1 Basic Usage.gdoc
@@ -27,7 +27,7 @@ class FacebookUser {
 At @Config.groovy@ setup full name (including package name, if used) of just created Facebook user domain, like:
 
 {code}
-grails.plugins.springsecurity.facebook.domain.classname='FacebookUser'
+grails.plugin.springsecurity.facebook.domain.classname='FacebookUser'
 {code}
 
 h3. Add FB App credentials
@@ -38,8 +38,8 @@ You should create a Facebook App and copy App ID and Secret:
 
 into @Config.groovy@:
 {code}
-grails.plugins.springsecurity.facebook.appId=12345678900000
-grails.plugins.springsecurity.facebook.secret=76c2279743c99da3715e3d00f29a1234
+grails.plugin.springsecurity.facebook.appId=12345678900000
+grails.plugin.springsecurity.facebook.secret=76c2279743c99da3715e3d00f29a1234
 {code}
 
 PS it's just example, you should use your own `appId` and `secret`.

--- a/src/docs/guide/3.2 Filters.gdoc
+++ b/src/docs/guide/3.2 Filters.gdoc
@@ -52,7 +52,7 @@ See [filter docs|guide:3.5 Json Authentication]
 
 h1. Filter configuration
 
-You can use config parameter @grails.plugins.springsecurity.facebook.filter.type@ to configure which filters
+You can use config parameter @grails.plugin.springsecurity.facebook.filter.type@ to configure which filters
 you want to use in your application.
 
 {note}
@@ -62,12 +62,12 @@ extra configuration, that used only by this plugin.
 
 By default it uses only one 'redirect' filter:
 {code}
-grails.plugins.springsecurity.facebook.filter.type='redirect'
+grails.plugin.springsecurity.facebook.filter.type='redirect'
 {code}
 
 You can use more that one filter at same time:
 {code}
-grails.plugins.springsecurity.facebook.filter.type='transparent,cookieDirect'
+grails.plugin.springsecurity.facebook.filter.type='transparent,cookieDirect'
 {code}
 
 Value types:

--- a/src/docs/guide/3.3 Server Side Authentication.gdoc
+++ b/src/docs/guide/3.3 Server Side Authentication.gdoc
@@ -37,7 +37,7 @@ beans = {
 and setup this bean for 'redirect' filter at @Config.groovy@:
 
 {code}
-grails.plugins.springsecurity.facebook.filter.redirect.failureHandler='redirectFailureHandlerExample'
+grails.plugin.springsecurity.facebook.filter.redirect.failureHandler='redirectFailureHandlerExample'
 {code}
 
 Same way for configuring Success Handler.

--- a/src/docs/guide/3.4 Client Side Authentication.gdoc
+++ b/src/docs/guide/3.4 Client Side Authentication.gdoc
@@ -21,7 +21,7 @@ on client side. Like:
 If you're using second way (@cookieDirect@ filter), you could configure URL that will be used for authentication at @Config.groovy@:
 
 {code}
-grails.plugins.springsecurity.facebook.filter.processUrl = '/j_spring_security_facebook_check' //it's default value
+grails.plugin.springsecurity.facebook.filter.processUrl = '/j_spring_security_facebook_check' //it's default value
 {code}
 
 And after authorization redirect user to /j_spring_security_facebook_check, like:

--- a/src/docs/guide/4 Configuration.gdoc
+++ b/src/docs/guide/4 Configuration.gdoc
@@ -8,9 +8,9 @@ Calling `grails s2-init-facebook` will make default configuration of plugin for 
 that you have configuration in your `Config.groovy` like:
 
 {code}
-grails.plugins.springsecurity.facebook.domain.classname='<your FacebookUser domain>'
-grails.plugins.springsecurity.facebook.secret = '<Facebook secret for your app>'
-grails.plugins.springsecurity.facebook.appId = '<Facebooks's app ID>'
+grails.plugin.springsecurity.facebook.domain.classname='<your FacebookUser domain>'
+grails.plugin.springsecurity.facebook.secret = '<Facebook secret for your app>'
+grails.plugin.springsecurity.facebook.appId = '<Facebooks's app ID>'
 {code}
 
 Or you can skip `grails s2-init-facebook` step, and make such configuration by yourself.

--- a/src/docs/guide/4.1 Facebook App Config.gdoc
+++ b/src/docs/guide/4.1 Facebook App Config.gdoc
@@ -1,12 +1,12 @@
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.secret | must be specified
-grails.plugins.springsecurity.facebook.appId | must be specified
+grails.plugin.springsecurity.facebook.secret | must be specified
+grails.plugin.springsecurity.facebook.appId | must be specified
 {table}
 
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.permissions | ['email']
+grails.plugin.springsecurity.facebook.permissions | ['email']
 {table}
 
 For a list of all possible permissions see [https://developers.facebook.com/docs/reference/login/#permissions|https://developers.facebook.com/docs/reference/login/#permissions]

--- a/src/docs/guide/4.2 Domains.gdoc
+++ b/src/docs/guide/4.2 Domains.gdoc
@@ -1,7 +1,7 @@
 {table}
 *Name* | *Default Value* | *Values*
-grails.plugins.springsecurity.facebook.domain.classname | 'FacebookUser' |
-grails.plugins.springsecurity.facebook.domain.appUserConnectionPropertyName | 'user' |
+grails.plugin.springsecurity.facebook.domain.classname | 'FacebookUser' |
+grails.plugin.springsecurity.facebook.domain.appUserConnectionPropertyName | 'user' |
 {table}
 
  * @domain.classname@ - name of your domain class, used to store Facebook User details (uid, access_token, etc). Could be same as configured for Spring Security Core, or a own domain, just for Facebook User details.
@@ -15,7 +15,7 @@ h4. User creation/initialization
 
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.autoCreate.roles | ['ROLE_USER', 'ROLE_FACEBOOK']
+grails.plugin.springsecurity.facebook.autoCreate.roles | ['ROLE_USER', 'ROLE_FACEBOOK']
 {table}
 
 List of roles for user created by the plugin.

--- a/src/docs/guide/4.3 Login Button.gdoc
+++ b/src/docs/guide/4.3 Login Button.gdoc
@@ -2,7 +2,7 @@ h4. Button configuration
 
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.taglib.button.text | 'Login with Facebook'
+grails.plugin.springsecurity.facebook.taglib.button.text | 'Login with Facebook'
 {table}
 
 h4. Button for Server Side authentication (default)
@@ -11,7 +11,7 @@ Standard @<img ... />@ will be used for button, with following extra configurati
 
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.taglib.button.img | an url for image distributed with plugin
+grails.plugin.springsecurity.facebook.taglib.button.img | an url for image distributed with plugin
 {table}
 
  * @img@ - url of a default image to use for button
@@ -22,7 +22,7 @@ At this case a HTML button, provided by Facebook JS SDK, will be user.
 
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.taglib.language | 'en_US'
+grails.plugin.springsecurity.facebook.taglib.language | 'en_US'
 {table}
 
  * @language@ - language for Facebook Javascript SDK. You could also pass this option as a @lang@ attribute for @:connect@ or @:init@ tags

--- a/src/docs/guide/4.4 Plugin Internals.gdoc
+++ b/src/docs/guide/4.4 Plugin Internals.gdoc
@@ -1,7 +1,7 @@
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.autoCreate.enabled | true
-grails.plugins.springsecurity.facebook.autoCreate.roles | ['ROLE_USER', 'ROLE_FACEBOOK']
+grails.plugin.springsecurity.facebook.autoCreate.enabled | true
+grails.plugin.springsecurity.facebook.autoCreate.roles | ['ROLE_USER', 'ROLE_FACEBOOK']
 {table}
 
  * autoCreate.enabled - enable/disabled automatic creation of Application User for a new Facebook user (when FB user first time authenticates)

--- a/src/docs/guide/4.5 Authentication Types.gdoc
+++ b/src/docs/guide/4.5 Authentication Types.gdoc
@@ -1,24 +1,24 @@
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.filter.processUrl | '/j_spring_security_facebook_check'
-grails.plugins.springsecurity.facebook.filter.type | 'redirect'
+grails.plugin.springsecurity.facebook.filter.processUrl | '/j_spring_security_facebook_check'
+grails.plugin.springsecurity.facebook.filter.type | 'redirect'
 {table}
 
  * @type@ - type of authentication, can be @transparent@, @cookieDirect@, @redirect@ or @json@.
 
 You can specify list of filters as a list @['redirect', 'json']@ or comma-separated string:
 {code}
-grails.plugins.springsecurity.facebook.filter.type='redirect,json'
+grails.plugin.springsecurity.facebook.filter.type='redirect,json'
 {code}
 
 h4. Configuration for REDIRECT filter
 
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.filter.redirect.processUrl | not set
-grails.plugins.springsecurity.facebook.filter.redirect.redirectFromUrl | '/j_spring_security_facebook_redirect'
-grails.plugins.springsecurity.facebook.filter.redirect.failureHandler | not set
-grails.plugins.springsecurity.facebook.filter.redirect.successHandler | not set
+grails.plugin.springsecurity.facebook.filter.redirect.processUrl | not set
+grails.plugin.springsecurity.facebook.filter.redirect.redirectFromUrl | '/j_spring_security_facebook_redirect'
+grails.plugin.springsecurity.facebook.filter.redirect.failureHandler | not set
+grails.plugin.springsecurity.facebook.filter.redirect.successHandler | not set
 {table}
 
  * @redirectFromUrl@ - it's the url that will redirect user to special Facebook Authentication URL. You can put link to/redirect user to @redirectFromUrl@ when you want to use Facebook authentication. This url is used by default @<facebook:connect />@ button.
@@ -34,9 +34,9 @@ h4. Configuration for COOKIEDIRECT filter
 
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.filter.cookieDirect.processUrl | not set
-grails.plugins.springsecurity.facebook.filter.cookieDirect.failureHandler | not set
-grails.plugins.springsecurity.facebook.filter.cookieDirect.successHandler | not set
+grails.plugin.springsecurity.facebook.filter.cookieDirect.processUrl | not set
+grails.plugin.springsecurity.facebook.filter.cookieDirect.failureHandler | not set
+grails.plugin.springsecurity.facebook.filter.cookieDirect.successHandler | not set
 {table}
 
  * if @filter.cookieDirect.processUrl@ is not set, then default @filter.processUrl@ will be used
@@ -47,9 +47,9 @@ h4. Configuration for JSON filter
 
 {table}
 *Name* | *Default Value*
-grails.plugins.springsecurity.facebook.filter.json.processUrl | '/j_spring_security_facebook_json'
-grails.plugins.springsecurity.facebook.filter.json.type | 'json'
-grails.plugins.springsecurity.facebook.filter.json.methods | ['POST']
+grails.plugin.springsecurity.facebook.filter.json.processUrl | '/j_spring_security_facebook_json'
+grails.plugin.springsecurity.facebook.filter.json.type | 'json'
+grails.plugin.springsecurity.facebook.filter.json.methods | ['POST']
 {table}
 
  * @type@ could be @json@ (default) or @jsonp@

--- a/src/groovy/com/the6hours/grails/springsecurity/facebook/DefaultFacebookAuthDao.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/facebook/DefaultFacebookAuthDao.groovy
@@ -372,19 +372,19 @@ class DefaultFacebookAuthDao implements FacebookAuthDao<Object, Object>, Initial
             Class<?> UserDomainClass = grailsApplication.getDomainClass(userDomainClassName)?.clazz
             if (UserDomainClass == null || !UserDetails.isAssignableFrom(UserDomainClass)) {
                 if (!conf.userLookup.authorityJoinClassName) {
-                    log.error("Don't have authority join class configuration. Please configure 'grails.plugins.springsecurity.userLookup.authorityJoinClassName' value")
+                    log.error("Don't have authority join class configuration. Please configure 'grails.plugin.springsecurity.userLookup.authorityJoinClassName' value")
                 } else if (!grailsApplication.getDomainClass(conf.userLookup.authorityJoinClassName)) {
-                    log.error("Can't find authority join class (${conf.userLookup.authorityJoinClassName}). Please configure 'grails.plugins.springsecurity.userLookup.authorityJoinClassName' value, or create your own 'List<GrantedAuthority> facebookAuthService.getRoles(user)'")
+                    log.error("Can't find authority join class (${conf.userLookup.authorityJoinClassName}). Please configure 'grails.plugin.springsecurity.userLookup.authorityJoinClassName' value, or create your own 'List<GrantedAuthority> facebookAuthService.getRoles(user)'")
                 }
             }
         }
         if (!serviceMethods.contains('findUser')) {
             if (!domainClassName) {
-                log.error("Don't have facebook user class configuration. Please configure 'grails.plugins.springsecurity.facebook.domain.classname' value")
+                log.error("Don't have facebook user class configuration. Please configure 'grails.plugin.springsecurity.facebook.domain.classname' value")
             } else {
                 Class<?> User = grailsApplication.getDomainClass(domainClassName)?.clazz
                 if (!User) {
-                    log.error("Can't find facebook user class ($domainClassName). Please configure 'grails.plugins.springsecurity.facebook.domain.classname' value, or create your own 'Object facebookAuthService.findUser(long)'")
+                    log.error("Can't find facebook user class ($domainClassName). Please configure 'grails.plugin.springsecurity.facebook.domain.classname' value, or create your own 'Object facebookAuthService.findUser(long)'")
                 }
             }
         }

--- a/src/groovy/com/the6hours/grails/springsecurity/facebook/FacebookAuthProvider.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/facebook/FacebookAuthProvider.groovy
@@ -68,7 +68,7 @@ public class FacebookAuthProvider implements AuthenticationProvider, Initializin
                 justCreated = true
             } else {
                 log.error "User $token.uid doesn't exist, and creation of a new user is disabled."
-                log.debug "To enabled auto creation of users set `grails.plugins.springsecurity.facebook.autoCreate.enabled` to true"
+                log.debug "To enabled auto creation of users set `grails.plugin.springsecurity.facebook.autoCreate.enabled` to true"
                 throw new UsernameNotFoundException("Facebook user with uid $token.uid doesn't exist")
             }
         }


### PR DESCRIPTION
Update config to get rid of warning about new namespace for spring security
springsecurity.ReflectionUtils Your security configuration settings use the old prefix 'grails.plugins.springsecurity' but must now use 'grails.plugin.springsecurity'

http://grails-plugins.github.io/grails-spring-security-core/docs/manual/guide/newInV2.html
