### PR TITLE
set authenticate=true when logging in from facebook

### DIFF
--- a/src/groovy/com/the6hours/grails/springsecurity/facebook/FacebookAuthRedirectFilter.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/facebook/FacebookAuthRedirectFilter.groovy
@@ -37,7 +37,9 @@ class FacebookAuthRedirectFilter extends AbstractAuthenticationProcessingFilter 
                     uid: -1,
                     redirectUri: getAbsoluteRedirectUrl()
             )
-            return authenticationManager.authenticate(token)
+            final Authentication result = authenticationManager.authenticate(token)
+            token.authenticated = true
+            return result
         }
         throw new InvalidRequestException("Request is empty")
     }


### PR DESCRIPTION
This is mostly a performance patch. Because not setting the authenticated=true flag makes Spring to
authenticate the request in every service call.

See issue #22 for more information.
