### PR TITLE
Fixes #79 - FacebookAuthToken.authorities is null when created

### DIFF
--- a/src/groovy/com/the6hours/grails/springsecurity/facebook/FacebookAuthToken.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/facebook/FacebookAuthToken.groovy
@@ -15,7 +15,7 @@ class FacebookAuthToken extends AbstractAuthenticationToken {
 
     def principal
 
-    Collection<GrantedAuthority> authorities
+    Collection<GrantedAuthority> authorities = [] as Collection<GrantedAuthority>
 
     FacebookAuthToken() {
         super([] as Collection<GrantedAuthority>)

--- a/test/unit/com/the6hours/grails/springsecurity/facebook/FacebookAuthTokenSpec.groovy
+++ b/test/unit/com/the6hours/grails/springsecurity/facebook/FacebookAuthTokenSpec.groovy
@@ -1,0 +1,28 @@
+package com.the6hours.grails.springsecurity.facebook
+
+import grails.test.mixin.TestMixin
+import grails.test.mixin.support.GrailsUnitTestMixin
+import spock.lang.Specification
+
+import com.the6hours.grails.springsecurity.facebook.FacebookAuthToken
+
+/**
+ * See the API for {@link grails.test.mixin.support.GrailsUnitTestMixin} for usage instructions
+ */
+@TestMixin(GrailsUnitTestMixin)
+class FacebookAuthTokenSpec extends Specification {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "authorities should not be null after construction"() {
+		given:
+		FacebookAuthToken token = new FacebookAuthToken()
+		
+		expect:
+		token.authorities != null 
+    }
+}


### PR DESCRIPTION
FacebookAuthToken.authorities is null when created, meaningthe toString() method causes a NPE