### PR TITLE
Add documentation about Facebook API version configuration.

### DIFF
--- a/src/docs/guide/4.1 Facebook App Config.gdoc
+++ b/src/docs/guide/4.1 Facebook App Config.gdoc
@@ -2,7 +2,11 @@
 *Name* | *Default Value*
 grails.plugin.springsecurity.facebook.secret | must be specified
 grails.plugin.springsecurity.facebook.appId | must be specified
+grails.plugin.springsecurity.facebook.apiVersion | not set
 {table}
+
+* @apiVersion@ - Facebook API version (e.g., "v2.2"). If not set is used unversioned Facebook API by default.
+
 
 {table}
 *Name* | *Default Value*


### PR DESCRIPTION
Adding documentation about Facebook API version configuration. It's important that developers are aware of this configuration to avoid that deprecated API version messages will be displayed for the users.