### PR TITLE
Give possibilty of implementing beforeCreate method

### DIFF
--- a/src/docs/guide/5.1 Using FacebookAuthService.gdoc
+++ b/src/docs/guide/5.1 Using FacebookAuthService.gdoc
@@ -125,4 +125,10 @@ Where:
   * person - your domain for <Person>
   * token - com.the6hours.grails.springsecurity.facebook.FacebookAuthToken
 
-h2. How to use
+h3. void beforeCreate(FacebookAuthToken token)
+
+Called before user was created by plugin. You can implement logic that aborts login. If method throws <AuthenticationException> you can handle this exception in failure handler.
+
+Where:
+
+  * token - com.the6hours.grails.springsecurity.facebook.FacebookAuthToken

--- a/src/groovy/com/the6hours/grails/springsecurity/facebook/FacebookAuthProvider.groovy
+++ b/src/groovy/com/the6hours/grails/springsecurity/facebook/FacebookAuthProvider.groovy
@@ -16,7 +16,6 @@ import org.springframework.security.core.userdetails.UserDetails
 import org.springframework.security.core.userdetails.UserDetailsChecker
 import org.springframework.security.core.userdetails.UsernameNotFoundException
 
-@CompileStatic
 class FacebookAuthProvider implements AuthenticationProvider, InitializingBean, ApplicationContextAware {
 
     private static final Logger log = LoggerFactory.getLogger(this)
@@ -69,6 +68,11 @@ class FacebookAuthProvider implements AuthenticationProvider, InitializingBean, 
                     log.error("Can't create user w/o access_token")
                     throw new CredentialsExpiredException("Can't receive access_token from Facebook")
                 }
+
+                if (facebookAuthService?.respondsTo('beforeCreate', FacebookAuthToken)) {
+                    facebookAuthService.beforeCreate(token)
+                }
+
                 user = facebookAuthDao.create(token)
                 justCreated = true
             } else {


### PR DESCRIPTION
```beforeCreate``` method can be implemented in ```FacebookAuthService``` to execute some logic before creating user. For example, you can implement logic that aborts login throws <AuthenticationException> and handle it in failure handler.